### PR TITLE
Fix empty $in crash on getLinked endpoint

### DIFF
--- a/server/models/dynamo/dynamo-query.js
+++ b/server/models/dynamo/dynamo-query.js
@@ -81,6 +81,7 @@ export default class DynamoQuery {
     const self = this;
     const promise = (async () => {
       const params = self._buildParams({ select: 'COUNT' });
+      if (params === null) return 0;
       const Command = self._index ? QueryCommand : ScanCommand;
       let count = 0;
       let next;
@@ -101,6 +102,7 @@ export default class DynamoQuery {
 
   async _runQuery() {
     const params = this._buildParams({ select: 'ALL' });
+    if (params === null) return [];
     const Command = this._index ? QueryCommand : ScanCommand;
     const items = [];
     let next;
@@ -126,6 +128,7 @@ export default class DynamoQuery {
     }
 
     const filterSpec = buildFilterExpression(this.filter, params.ExpressionAttributeValues || {}, params.ExpressionAttributeNames || {});
+    if (filterSpec.emptyIn) return null;
     if (filterSpec.expression) {
       params.FilterExpression = filterSpec.expression;
       params.ExpressionAttributeValues = filterSpec.values;
@@ -170,10 +173,11 @@ function buildFilterExpression(filter, valuesIn = {}, namesIn = {}) {
   const ctx = {
     values: { ...valuesIn },
     names: { ...namesIn },
-    counter: 0
+    counter: 0,
+    _emptyIn: false
   };
   const expression = buildExpressionInner(filter || {}, ctx);
-  return { expression, values: ctx.values, names: ctx.names };
+  return { expression, values: ctx.values, names: ctx.names, emptyIn: ctx._emptyIn };
 }
 
 function buildExpressionInner(filter, ctx) {
@@ -212,6 +216,10 @@ function handleCondition(field, condition, ctx) {
     case '$lt': parts.push(`${name} < ${registerValue(rhs, ctx)}`); break;
     case '$lte': parts.push(`${name} <= ${registerValue(rhs, ctx)}`); break;
     case '$in': {
+      if (!Array.isArray(rhs) || rhs.length === 0) {
+        ctx._emptyIn = true;
+        break;
+      }
       const keys = rhs.map(val => registerValue(val, ctx));
       parts.push(`${name} IN (${keys.join(', ')})`);
       break;

--- a/server/tests/unit/dynamo-cost-optimization.test.js
+++ b/server/tests/unit/dynamo-cost-optimization.test.js
@@ -203,3 +203,20 @@ describe('Cost Optimization: Controller type param mapping', () => {
     expect(ids1).to.deep.equal(ids2);
   });
 });
+
+describe('Fix: Empty $in does not crash DynamoDB (getLinked alert)', () => {
+  it('Marker.find with empty $in returns empty array (no DynamoDB call)', async () => {
+    const results = await MarkerDynamo.find({ _id: { $in: [] } }).lean().exec();
+    expect(results).to.be.an('array').that.is.empty;
+  });
+
+  it('Metadata.find with empty $in returns empty array', async () => {
+    const results = await MetadataDynamo.find({ _id: { $in: [] } }).lean().exec();
+    expect(results).to.be.an('array').that.is.empty;
+  });
+
+  it('countDocuments with empty $in returns 0', async () => {
+    const count = await MarkerDynamo.find({ _id: { $in: [] } }).countDocuments().exec();
+    expect(count).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the two alerts from this morning (04:14 UTC): **"Lambda errors"** and **"API Gateway 500 anomaly"**
- Root cause: `GET /v1/metadata/links/getLinked` calls `Marker.find({ _id: { $in: [] } })` when linked items have no markers. The empty `$in` array produced an invalid DynamoDB expression (`IN ()`) causing `ValidationException: ExpressionAttributeValues must not be empty`
- Fix: `DynamoQuery` short-circuits to empty results when `$in` has an empty array — no DynamoDB call is made

## Test plan

- [x] 3 new unit tests covering empty `$in` on find, lean, and countDocuments
- [x] Full suite: 246 passing, 0 failures
- [ ] Verify no more 500s on `getLinked` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)