### PR TITLE
Fix review feedback: end bug, cache poisoning, $in/$or, dead code

### DIFF
--- a/server/boardComponent/entities/discussion/model.dynamo.js
+++ b/server/boardComponent/entities/discussion/model.dynamo.js
@@ -163,27 +163,19 @@ async function queryDiscussions(filter) {
     return (Items || []).filter(i => i.entityType === 'discussion').map(toDiscussion);
   }
   if (filter.forum_id) {
-    try {
-      const { Items } = await getDocClient().send(new QueryCommand({
-        TableName: TABLE,
-        IndexName: 'GSI-ForumId',
-        KeyConditionExpression: '#fid = :fid',
-        ExpressionAttributeNames: { '#fid': 'forum_id' },
-        ExpressionAttributeValues: { ':fid': String(filter.forum_id) },
-        ScanIndexForward: false
-      }));
-      let items = (Items || []).filter(i => i.entityType === 'discussion').map(toDiscussion);
-      if (typeof filter.pinned !== 'undefined') {
-        items = items.filter(d => d.pinned === filter.pinned);
-      }
-      return items;
-    } catch (err) {
-      if (err.name === 'ResourceNotFoundException') {
-        // GSI not yet active — fall through to scan
-      } else {
-        throw err;
-      }
+    const { Items } = await getDocClient().send(new QueryCommand({
+      TableName: TABLE,
+      IndexName: 'GSI-ForumId',
+      KeyConditionExpression: '#fid = :fid',
+      ExpressionAttributeNames: { '#fid': 'forum_id' },
+      ExpressionAttributeValues: { ':fid': String(filter.forum_id) },
+      ScanIndexForward: false
+    }));
+    let items = (Items || []).filter(i => i.entityType === 'discussion').map(toDiscussion);
+    if (typeof filter.pinned !== 'undefined') {
+      items = items.filter(d => d.pinned === filter.pinned);
     }
+    return items;
   }
   const items = await scanDiscussions();
   return items.filter(d => {

--- a/server/controllers/marker.controller.js
+++ b/server/controllers/marker.controller.js
@@ -177,7 +177,7 @@ function list(req, res, next) {
   const wikiArray = req.query.wikis || false;
   const format = req.query.format || false;
   const year = isNaN(req.query.year) ? false : +req.query.year;
-  const end = isNaN(req.query.year) ? false : +req.query.year;
+  const end = isNaN(req.query.end) ? false : +req.query.end;
   const delta = +req.query.delta;
   const includeMarkers = req.query.includeMarkers !== 'false';
   const search = req.query.search || false;

--- a/server/models/dynamo/area.dynamo.js
+++ b/server/models/dynamo/area.dynamo.js
@@ -84,6 +84,7 @@ export default class AreaDynamo extends DynamoDocument {
       TableName: TABLE,
       Item: item
     }));
+    cache.del(`area:${item._id}`);
     return this;
   }
 

--- a/server/models/dynamo/dynamo-query.js
+++ b/server/models/dynamo/dynamo-query.js
@@ -128,7 +128,7 @@ export default class DynamoQuery {
     }
 
     const filterSpec = buildFilterExpression(this.filter, params.ExpressionAttributeValues || {}, params.ExpressionAttributeNames || {});
-    if (filterSpec.emptyIn) return null;
+    if (filterSpec.neverMatches) return null;
     if (filterSpec.expression) {
       params.FilterExpression = filterSpec.expression;
       params.ExpressionAttributeValues = filterSpec.values;
@@ -169,15 +169,19 @@ export default class DynamoQuery {
  * the top level. Anything unsupported throws — fail loud, don't silently
  * return wrong results.
  */
+const EMPTY_IN_SENTINEL = '__empty_in_never_matches__';
+
 function buildFilterExpression(filter, valuesIn = {}, namesIn = {}) {
   const ctx = {
     values: { ...valuesIn },
     names: { ...namesIn },
     counter: 0,
-    _emptyIn: false
+    hasOr: false,
+    hasEmptyIn: false
   };
   const expression = buildExpressionInner(filter || {}, ctx);
-  return { expression, values: ctx.values, names: ctx.names, emptyIn: ctx._emptyIn };
+  const neverMatches = ctx.hasEmptyIn && !ctx.hasOr;
+  return { expression, values: ctx.values, names: ctx.names, neverMatches };
 }
 
 function buildExpressionInner(filter, ctx) {
@@ -185,6 +189,7 @@ function buildExpressionInner(filter, ctx) {
   for (const [key, value] of Object.entries(filter)) {
     if (key === '$or') {
       if (!Array.isArray(value)) throw new Error('$or must be an array');
+      ctx.hasOr = true;
       const orParts = value
         .map(sub => buildExpressionInner(sub, ctx))
         .filter(Boolean)
@@ -217,7 +222,8 @@ function handleCondition(field, condition, ctx) {
     case '$lte': parts.push(`${name} <= ${registerValue(rhs, ctx)}`); break;
     case '$in': {
       if (!Array.isArray(rhs) || rhs.length === 0) {
-        ctx._emptyIn = true;
+        ctx.hasEmptyIn = true;
+        parts.push(`${name} = ${registerValue(EMPTY_IN_SENTINEL, ctx)}`);
         break;
       }
       const keys = rhs.map(val => registerValue(val, ctx));

--- a/server/models/dynamo/metadata.dynamo.js
+++ b/server/models/dynamo/metadata.dynamo.js
@@ -112,7 +112,11 @@ export default class MetadataDynamo extends DynamoDocument {
   async save(options = {}) {
     const item = prepareForWrite(this.toObject());
     await getDocClient().send(new PutCommand({ TableName: TABLE, Item: item }));
-    cache.clear();
+    for (const key of cache.keys()) {
+      if (key.startsWith('query:') || key.startsWith('default:') || key.startsWith('init:')) {
+        cache.del(key);
+      }
+    }
     return this;
   }
 }
@@ -169,7 +173,7 @@ async function queryBranch(options) {
     wiki, search, mustGeo, discover
   } = options;
 
-  const cacheKey = `query:${type}:${subtype}:${year}:${delta}:${start}:${end}:${wiki || ''}:${search || ''}:${mustGeo || ''}`;
+  const cacheKey = `query:${type}:${subtype}:${year}:${delta}:${start}:${end}:${wiki || ''}:${search || ''}:${mustGeo || ''}:${discover || ''}`;
   const cached = cache.get(cacheKey);
   if (cached) return cached;
 

--- a/server/tests/unit/dynamo-cost-optimization.test.js
+++ b/server/tests/unit/dynamo-cost-optimization.test.js
@@ -205,7 +205,7 @@ describe('Cost Optimization: Controller type param mapping', () => {
 });
 
 describe('Fix: Empty $in does not crash DynamoDB (getLinked alert)', () => {
-  it('Marker.find with empty $in returns empty array (no DynamoDB call)', async () => {
+  it('Marker.find with empty $in returns empty array', async () => {
     const results = await MarkerDynamo.find({ _id: { $in: [] } }).lean().exec();
     expect(results).to.be.an('array').that.is.empty;
   });
@@ -218,5 +218,14 @@ describe('Fix: Empty $in does not crash DynamoDB (getLinked alert)', () => {
   it('countDocuments with empty $in returns 0', async () => {
     const count = await MarkerDynamo.find({ _id: { $in: [] } }).countDocuments().exec();
     expect(count).to.equal(0);
+  });
+
+  it('$or with empty $in branch still returns results from other branch', async () => {
+    const results = await MarkerDynamo.find({
+      $or: [{ type: 'e' }, { _id: { $in: [] } }]
+    }).lean().exec();
+    expect(results).to.be.an('array');
+    expect(results.length).to.be.greaterThan(0);
+    results.forEach(m => expect(m.type).to.equal('e'));
   });
 });


### PR DESCRIPTION
## Summary

Addresses all 6 issues from code review:

1. **`end` = `year` bug** — was silently dropping markers in the upper half of the delta range. Now correctly reads `req.query.end` as a separate param.
2. **Cache poisoning** — metadata cache key was missing `discover` param. Two requests with different `discover` values got same cached result.
3. **`cache.clear()` nuking everything** — metadata save was clearing area cache too. Now only deletes metadata-prefixed keys.
4. **Area cache not invalidated on write** — added `cache.del()` in area save.
5. **`$in: []` breaking `$or`** — reworked to produce a never-matching condition at the expression level instead of aborting the entire query. `$or` with empty `$in` branch now works correctly.
6. **Dead GSI fallback try/catch** — removed (GSI is ACTIVE, catch was for wrong exception type anyway).

## Test plan
- [x] 247 tests passing (including new `$or` + empty `$in` test)
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)