### PR TITLE
security: bump axios to fix follow-redirects (runtime alert)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/lib-dynamodb": "^3.1037.0",
         "@vendia/serverless-express": "4.12.6",
         "aws-xray-sdk": "^3.5.0",
-        "axios": "^1.15.2",
+        "axios": "^1.16.0",
         "bcryptjs": "^3.0.2",
         "compression": "^1.7.4",
         "cookie-parser": "^1.4.6",
@@ -2877,12 +2877,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -4863,9 +4863,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@aws-sdk/lib-dynamodb": "^3.1037.0",
     "@vendia/serverless-express": "4.12.6",
     "aws-xray-sdk": "^3.5.0",
-    "axios": "^1.15.2",
+    "axios": "^1.16.0",
     "bcryptjs": "^3.0.2",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",


### PR DESCRIPTION
## Summary
- Bumps `axios ^1.15.2 → ^1.16.0`, which transitively pulls in `follow-redirects@1.16.0`.
- Closes the only **runtime-scope** Dependabot alert: [#295](https://github.com/Chronasorg/chronas-api/security/dependabot/295) — `follow-redirects` leaks Custom Authentication headers to cross-domain redirect targets (GHSA-jchw-25xp-jwwc).
- The other 20 open alerts are all dev-scope (mocha/newman/eslint transitives) and will be addressed in a follow-up PR via `overrides`.

## Test plan
- [x] `npm test` — 223 passing locally (mocha + dynalite)
- [ ] Postman dev smoke (runs automatically post-deploy via `deploy-prod.yml`)
- [ ] Verify alert #295 is auto-closed by Dependabot after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)