### PR TITLE
security: CodeQL batch A — workflow perms, critical type fix, error sanitization, secure cookies

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,6 +8,9 @@ concurrency:
   group: deploy-prod
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 env:
   S3_BUCKET: chronas-lambda-deployments
   AWS_REGION: eu-west-1

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: pr-ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/config/express.js
+++ b/config/express.js
@@ -94,7 +94,11 @@ if (config.env !== 'test') {
     secret: config.jwtSecret || 'test-secret-key',
     resave: false,
     saveUninitialized: false,
-    cookie: { secure: false }
+    cookie: {
+      secure: config.env === 'production',
+      httpOnly: true,
+      sameSite: 'lax'
+    }
   }));
 }
 

--- a/server/controllers/area.controller.js
+++ b/server/controllers/area.controller.js
@@ -175,11 +175,11 @@ function aggregateProvinces(req, res, next, resolve = false) {
           if (resolve) return resolve();
           res.send('OK');
         } catch (e) {
-          res.status(500).send(e);
+          res.status(500).send(e.message || 'Internal error');
         }
       });
     })
-    .catch(e => res.status(500).send(e));
+    .catch(e => res.status(500).send(e.message || 'Internal error'));
 }
 
 function aggregateMetaCoo(req, res, next, _resolve = false) {
@@ -357,11 +357,11 @@ function aggregateDimension(req, res, next, resolve = false) {
           if (resolve) return resolve();
           res.send('OK');
         } catch (e) {
-          res.status(500).send(e);
+          res.status(500).send(e.message || 'Internal error');
         }
       });
     })
-    .catch(e => res.status(500).send(e));
+    .catch(e => res.status(500).send(e.message || 'Internal error'));
 }
 
 function _addRemoveLink(req, res, next, el, eORa, replaceWithId, toReplaceLinkId) {

--- a/server/models/dynamo/metadata.dynamo.js
+++ b/server/models/dynamo/metadata.dynamo.js
@@ -160,7 +160,8 @@ async function fListBranch(fList, type, subtype, locale) {
   const result = {};
   for (const item of items) {
     const decoded = decodeFromRead(item);
-    const key = countLength ? decoded._id.substr(0, decoded._id.length - countLength) : decoded._id;
+    const id = String(decoded._id);
+    const key = countLength ? id.substr(0, id.length - countLength) : id;
     result[key] = decoded.data;
   }
   cache.put(cacheKey, result, CACHETTL);


### PR DESCRIPTION
## Summary

Closes 7 CodeQL alerts:

| Alert | Severity | Change |
|---|---|---|
| #1, #2 actions/missing-workflow-permissions | medium | Add explicit `permissions:` blocks to both workflows |
| **#9 js/type-confusion-through-parameter-tampering** | **critical** | `String(decoded._id)` cast in `fListBranch` |
| #7, #8 js/stack-trace-exposure | medium | `res.send(err.message)` instead of `res.send(err)` |
| #28 js/xss-through-exception | medium | Same as above (same callsite) |
| #6 js/clear-text-cookie | medium | Enable `secure`/`httpOnly`/`sameSite` on express-session in prod |

## Notes

- **#9** is the critical one. `decoded._id` from DynamoDB could in theory be a number from older data (the schema used to allow it); calling `.length` on a number returns `undefined`, then `.substr(0, NaN)` returns `''`, which would silently produce wrong cache keys. The `String()` cast makes the type guarantee explicit and matches the same pattern used elsewhere in the file (`batchGetByIds` already casts to String).
- **#6** uses `config.env === 'production'` to gate `secure: true`. Dev/test envs may run over plain HTTP, so this preserves local dev while hardening prod.
- **deploy-prod.yml** gets `contents: write` (it pushes the version-bump commit). **pr-ci.yml** gets `contents: read` (read-only).

## Test plan
- [x] `npm test` — 223 passing
- [x] Linter clean (no new findings introduced)
- [ ] Post-deploy: confirm no functional regressions in `/v1/areas/*` PUT or `/v1/metadata/links/*`
- [ ] Verify CodeQL re-scan shows alerts #1, #2, #6, #7, #8, #9, #28 as resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)