### PR TITLE
security: residual CodeQL fixes after batches A/B

### DIFF
--- a/server/controllers/area.controller.js
+++ b/server/controllers/area.controller.js
@@ -175,11 +175,11 @@ function aggregateProvinces(req, res, next, resolve = false) {
           if (resolve) return resolve();
           res.send('OK');
         } catch (e) {
-          res.status(500).send(e.message || 'Internal error');
+          res.status(500).send('Internal error');
         }
       });
     })
-    .catch(e => res.status(500).send(e.message || 'Internal error'));
+    .catch(e => res.status(500).send('Internal error'));
 }
 
 function aggregateMetaCoo(req, res, next, _resolve = false) {
@@ -357,11 +357,11 @@ function aggregateDimension(req, res, next, resolve = false) {
           if (resolve) return resolve();
           res.send('OK');
         } catch (e) {
-          res.status(500).send(e.message || 'Internal error');
+          res.status(500).send('Internal error');
         }
       });
     })
-    .catch(e => res.status(500).send(e.message || 'Internal error'));
+    .catch(e => res.status(500).send('Internal error'));
 }
 
 function _addRemoveLink(req, res, next, el, eORa, replaceWithId, toReplaceLinkId) {

--- a/server/models/dynamo/metadata.dynamo.js
+++ b/server/models/dynamo/metadata.dynamo.js
@@ -149,14 +149,14 @@ async function batchGetByIds(ids) {
 }
 
 async function fListBranch(fList, type, subtype, locale) {
-  const cacheKey = `init:${fList}:${locale || ''}`;
+  const localeStr = typeof locale === 'string' ? locale : '';
+  const cacheKey = `init:${fList}:${localeStr}`;
   const cachedInit = cache.get(cacheKey);
   if (cachedInit) return cachedInit;
 
-  const resourceArray = fList.split(',');
+  const resourceArray = String(fList).split(',');
   const items = await batchGetByIds(resourceArray);
-  let countLength = 0;
-  if (locale) countLength = locale.length + 1;
+  const countLength = localeStr ? localeStr.length + 1 : 0;
   const result = {};
   for (const item of items) {
     const decoded = decodeFromRead(item);


### PR DESCRIPTION
## Summary

When CodeQL re-scanned master after batches A & B merged, two of the previously-listed alerts remained because the actual root cause wasn't the line I changed. This PR closes them properly.

| Alert | Severity | Original fix | Why it didn't close | Real fix |
|---|---|---|---|---|
| **#9** js/type-confusion-through-parameter-tampering | **critical** | Cast `_id` to String | The taint is on `locale.length` — `locale` arrives from the request | Coerce `locale` to string explicitly + coerce `fList` for symmetry |
| **#34** js/xss-through-exception | medium | `res.send(e.message \|\| 'Internal error')` | `e.message` can contain attacker-influenced text from DynamoDB errors | `res.send('Internal error')` static string |

## Test plan
- [x] `npm test` — 223 passing
- [ ] CodeQL re-scan after merge: alerts #9 and #34 close

## Remaining open alerts (handled outside this PR)

Four alerts will close on the next master CodeQL scan once it sees the actual fixes from PRs #142/#143:

- #31, #32, #33 (rate-limiting on auth routes — fixed in #143)
- #36 (express-session CSRF — discuss separately; required by Passport OAuth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)