### PR TITLE
security: inline auth rate-limiters for CodeQL recognition

### DIFF
--- a/server/middleware/rate-limit.js
+++ b/server/middleware/rate-limit.js
@@ -1,26 +1,7 @@
 import rateLimit from 'express-rate-limit';
 
-const FIFTEEN_MINUTES = 15 * 60 * 1000;
-const ONE_HOUR = 60 * 60 * 1000;
-
-export const authLimiter = rateLimit({
-  windowMs: FIFTEEN_MINUTES,
-  limit: 10,
-  standardHeaders: 'draft-7',
-  legacyHeaders: false,
-  message: { message: 'Too many auth attempts, try again later.' }
-});
-
-export const refreshLimiter = rateLimit({
-  windowMs: FIFTEEN_MINUTES,
-  limit: 30,
-  standardHeaders: 'draft-7',
-  legacyHeaders: false,
-  message: { message: 'Too many refresh attempts, try again later.' }
-});
-
 export const contactLimiter = rateLimit({
-  windowMs: ONE_HOUR,
+  windowMs: 60 * 60 * 1000,
   limit: 3,
   standardHeaders: 'draft-7',
   legacyHeaders: false,

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { expressjwt as expressJwt } from 'express-jwt';
+import rateLimit from 'express-rate-limit';
 
 import { validate } from '../helpers/validation.js';
 import paramValidation from '../../config/param-validation.js';
@@ -8,9 +9,24 @@ import authCtrl from '../controllers/auth.controller.js';
 import facebook from '../auths/facebook.js';
 import google from '../auths/google.js';
 import github from '../auths/github.js';
-import { authLimiter, refreshLimiter } from '../middleware/rate-limit.js';
 
 const router = express.Router();
+
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { message: 'Too many auth attempts, try again later.' }
+});
+
+const refreshLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 30,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: { message: 'Too many refresh attempts, try again later.' }
+});
 
 /** POST /v1/auth/login - Returns token if correct email and password is provided */
 router.route('/login')


### PR DESCRIPTION
## Summary
- CodeQL's `js/missing-rate-limiting` doesn't trace imported middleware constants across module boundaries, so it kept flagging alerts #31, #32, #33 even though `authLimiter`/`refreshLimiter` from `../middleware/rate-limit.js` were applied.
- Inlining the `rateLimit({...})` calls in `auth.route.js` makes the connection visible to the analyzer.
- No behavioural change — same limits, same package, same routes.
- `contactLimiter` stays in the middleware module (single-use, no CodeQL alert on contact route).

## Test plan
- [x] `npm test` — 223 passing
- [ ] CodeQL re-scan after merge: alerts #31, #32, #33 close

🤖 Generated with [Claude Code](https://claude.com/claude-code)