### PR TITLE
security: persist rate-limit counters in DynamoDB (Lambda-safe) + tune limits

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -41,6 +41,7 @@ deletion protection on). Pre-computed stats JSON is in S3.
 | `chronas-revisions` | Edit history (GSI-EntityTimestamp) |
 | `chronas-links` | Normalized per-entity links |
 | `chronas-board` | Forum posts/discussions/opinions |
+| `chronas-rate-limits` | Per-IP rate-limit counters for /auth/* and /contact (TTL on `expires_at`) |
 | `chronas-collections` | (unused — `/v1/collections` retired, returns 410) |
 | `chronas-games` | (unused — `/v1/game` retired, returns 410) |
 

--- a/server/middleware/dynamo-rate-store.js
+++ b/server/middleware/dynamo-rate-store.js
@@ -1,0 +1,84 @@
+import { UpdateCommand, DeleteCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+
+import { getDocClient, tableName } from '../models/dynamo/dynamo-client.js';
+
+const TABLE = tableName('rate-limits');
+
+export class DynamoRateLimitStore {
+  constructor({ prefix = '', windowMs }) {
+    this.prefix = prefix;
+    this.windowMs = windowMs;
+    this.localKeys = new Map();
+  }
+
+  init(options) {
+    if (!this.windowMs) this.windowMs = options.windowMs;
+  }
+
+  _id(key) {
+    return `${this.prefix}:${key}`;
+  }
+
+  async increment(key) {
+    const id = this._id(key);
+    const now = Date.now();
+    const expiresAt = Math.floor((now + this.windowMs) / 1000);
+
+    const { Attributes } = await getDocClient().send(new UpdateCommand({
+      TableName: TABLE,
+      Key: { _id: id },
+      UpdateExpression: 'ADD #c :one SET expires_at = if_not_exists(expires_at, :exp), reset_at = if_not_exists(reset_at, :reset)',
+      ExpressionAttributeNames: { '#c': 'count' },
+      ExpressionAttributeValues: { ':one': 1, ':exp': expiresAt, ':reset': now + this.windowMs },
+      ReturnValues: 'ALL_NEW'
+    }));
+
+    let totalHits = Attributes?.count ?? 1;
+    let resetAt = Attributes?.reset_at ?? (now + this.windowMs);
+
+    if (now >= resetAt) {
+      await getDocClient().send(new DeleteCommand({ TableName: TABLE, Key: { _id: id } }));
+      const fresh = await getDocClient().send(new UpdateCommand({
+        TableName: TABLE,
+        Key: { _id: id },
+        UpdateExpression: 'SET #c = :one, expires_at = :exp, reset_at = :reset',
+        ExpressionAttributeNames: { '#c': 'count' },
+        ExpressionAttributeValues: { ':one': 1, ':exp': expiresAt, ':reset': now + this.windowMs },
+        ReturnValues: 'ALL_NEW'
+      }));
+      totalHits = fresh.Attributes?.count ?? 1;
+      resetAt = fresh.Attributes?.reset_at ?? (now + this.windowMs);
+    }
+
+    return { totalHits, resetTime: new Date(resetAt) };
+  }
+
+  async decrement(key) {
+    const id = this._id(key);
+    try {
+      await getDocClient().send(new UpdateCommand({
+        TableName: TABLE,
+        Key: { _id: id },
+        UpdateExpression: 'ADD #c :neg',
+        ConditionExpression: 'attribute_exists(#c) AND #c > :zero',
+        ExpressionAttributeNames: { '#c': 'count' },
+        ExpressionAttributeValues: { ':neg': -1, ':zero': 0 }
+      }));
+    } catch (err) {
+      if (err.name !== 'ConditionalCheckFailedException') throw err;
+    }
+  }
+
+  async resetKey(key) {
+    await getDocClient().send(new DeleteCommand({ TableName: TABLE, Key: { _id: this._id(key) } }));
+  }
+
+  async get(key) {
+    const { Item } = await getDocClient().send(new GetCommand({
+      TableName: TABLE,
+      Key: { _id: this._id(key) }
+    }));
+    if (!Item) return undefined;
+    return { totalHits: Item.count ?? 0, resetTime: new Date(Item.reset_at ?? Date.now()) };
+  }
+}

--- a/server/middleware/rate-limit.js
+++ b/server/middleware/rate-limit.js
@@ -1,9 +1,14 @@
 import rateLimit from 'express-rate-limit';
 
+import { DynamoRateLimitStore } from './dynamo-rate-store.js';
+
+const ONE_HOUR = 60 * 60 * 1000;
+
 export const contactLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000,
-  limit: 3,
+  windowMs: ONE_HOUR,
+  limit: 5,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
+  store: new DynamoRateLimitStore({ prefix: 'contact', windowMs: ONE_HOUR }),
   message: { message: 'Too many contact submissions, try again later.' }
 });

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -9,22 +9,27 @@ import authCtrl from '../controllers/auth.controller.js';
 import facebook from '../auths/facebook.js';
 import google from '../auths/google.js';
 import github from '../auths/github.js';
+import { DynamoRateLimitStore } from '../middleware/dynamo-rate-store.js';
 
 const router = express.Router();
 
+const FIFTEEN_MIN = 15 * 60 * 1000;
+
 const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 10,
+  windowMs: FIFTEEN_MIN,
+  limit: 20,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
+  store: new DynamoRateLimitStore({ prefix: 'auth', windowMs: FIFTEEN_MIN }),
   message: { message: 'Too many auth attempts, try again later.' }
 });
 
 const refreshLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 30,
+  windowMs: FIFTEEN_MIN,
+  limit: 60,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
+  store: new DynamoRateLimitStore({ prefix: 'refresh', windowMs: FIFTEEN_MIN }),
   message: { message: 'Too many refresh attempts, try again later.' }
 });
 


### PR DESCRIPTION
## Why

Code review caught that the previous \`express-rate-limit\` setup used the default in-memory store, which is per-Lambda-instance. With concurrent invocations and cold starts each container had its own counter, making the limit useless against real attackers — security theater.

## What

- New \`DynamoDBStore\` class in \`server/middleware/dynamo-rate-store.js\` (~80 lines, implements the express-rate-limit \`Store\` interface using the existing \`@aws-sdk/lib-dynamodb\` doc client — no new deps).
- New DynamoDB table \`chronas-rate-limits\` (PAY_PER_REQUEST, TTL on \`expires_at\`, deletion-protection on). Lambda IAM already grants \`chronas-*\` table access — no policy change.
- Wired into \`/auth/login\`, \`/auth/signup\`, \`/auth/refresh\`, \`/contact\`.
- Counters persist across Lambda cold starts and are shared across concurrent containers.

## Limit tuning (sweet spot — won't bite real users)

| Route | Old | New | Rationale |
|---|---|---|---|
| \`/auth/login\` | 10 / 15min / IP | **20 / 15min / IP** | Handles password mistypes + retries; still kills credential stuffing |
| \`/auth/signup\` | 10 / 15min / IP | **20 / 15min / IP** | Symmetric to login |
| \`/auth/refresh\` | 30 / 15min / IP | **60 / 15min / IP** | Corporate NATs, multiple sessions per IP |
| \`/contact\` | 3 / hour / IP | **5 / hour / IP** | Still tight — anonymous endpoint |

## Infra changes (already applied — pre-PR)

\`\`\`
aws --profile chronas-prod --region eu-west-1 dynamodb create-table \\
  --table-name chronas-rate-limits \\
  --attribute-definitions AttributeName=_id,AttributeType=S \\
  --key-schema AttributeName=_id,KeyType=HASH \\
  --billing-mode PAY_PER_REQUEST \\
  --tags Key=app,Value=chronas Key=auto-stop,Value=no Key=auto-delete,Value=never

aws --profile chronas-prod --region eu-west-1 dynamodb update-time-to-live \\
  --table-name chronas-rate-limits \\
  --time-to-live-specification 'Enabled=true, AttributeName=expires_at'

aws --profile chronas-prod --region eu-west-1 dynamodb update-table \\
  --table-name chronas-rate-limits --deletion-protection-enabled
\`\`\`

Documented in \`infra/README.md\`.

## Test plan
- [x] \`npm test\` — 223 passing
- [ ] Post-deploy: hit \`/v1/auth/login\` 21x rapidly from one IP → 21st returns 429 with \`RateLimit-Remaining: 0\`
- [ ] Post-deploy: confirm normal user flows (login, refresh, contact) still work end-to-end via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)