### PR TITLE
fix: set 'trust proxy' so rate-limit sees real client IP (caught by Lambda log audit)

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -24,6 +24,8 @@ import { createPerformanceMiddleware } from './performance.js';
 
 const app = express();
 
+app.set('trust proxy', 2);
+
 app.use(AWSXRay.express.openSegment('Chronas-Api'));
 
 // Set up Swagger documentation with graceful fallback

--- a/e2e-tests/explore.spec.js
+++ b/e2e-tests/explore.spec.js
@@ -1,0 +1,76 @@
+import { test } from '@playwright/test';
+import fs from 'fs';
+
+const FRONTEND = 'https://chronas.org';
+
+test('explore chronas.org DOM structure', async ({ page }) => {
+  test.setTimeout(60000);
+
+  await page.goto(FRONTEND, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.waitForTimeout(8000);
+
+  await page.screenshot({ path: 'test-results/explore-home.png', fullPage: false });
+
+  const buttons = await page.locator('button, [role="button"]').evaluateAll((nodes) =>
+    nodes.slice(0, 60).map((n) => ({
+      text: (n.textContent || '').trim().slice(0, 40),
+      aria: n.getAttribute('aria-label'),
+      cls: (n.getAttribute('class') || '').slice(0, 80)
+    }))
+  );
+
+  const inputs = await page.locator('input').evaluateAll((nodes) =>
+    nodes.slice(0, 30).map((n) => ({
+      type: n.getAttribute('type'),
+      name: n.getAttribute('name'),
+      placeholder: n.getAttribute('placeholder'),
+      aria: n.getAttribute('aria-label'),
+      cls: (n.getAttribute('class') || '').slice(0, 80)
+    }))
+  );
+
+  const dataAttrs = await page.evaluate(() => {
+    const els = document.querySelectorAll('[data-testid],[data-test],[data-cy]');
+    return Array.from(els).slice(0, 40).map((el) => ({
+      tag: el.tagName.toLowerCase(),
+      testid: el.getAttribute('data-testid') || el.getAttribute('data-test') || el.getAttribute('data-cy'),
+      text: (el.textContent || '').trim().slice(0, 40)
+    }));
+  });
+
+  const sliders = await page.locator('[role="slider"], input[type="range"], .timeline, [class*="timeline" i], [class*="year" i]').evaluateAll((nodes) =>
+    nodes.slice(0, 20).map((n) => ({
+      tag: n.tagName.toLowerCase(),
+      role: n.getAttribute('role'),
+      cls: (n.getAttribute('class') || '').slice(0, 100),
+      text: (n.textContent || '').trim().slice(0, 40)
+    }))
+  );
+
+  const navLinks = await page.locator('a, [role="link"], nav button').evaluateAll((nodes) =>
+    nodes.slice(0, 30).map((n) => ({
+      text: (n.textContent || '').trim().slice(0, 40),
+      href: n.getAttribute('href'),
+      cls: (n.getAttribute('class') || '').slice(0, 80)
+    }))
+  );
+
+  const html = await page.content();
+  fs.writeFileSync('test-results/explore-dump.json', JSON.stringify({
+    title: await page.title(),
+    url: page.url(),
+    buttons: buttons.filter(b => b.text || b.aria || b.cls.length > 0),
+    inputs,
+    dataAttrs,
+    sliders,
+    navLinks: navLinks.filter(n => n.text || n.href),
+    htmlLength: html.length
+  }, null, 2));
+
+  console.log('\n\n=== EXPLORE DUMP ===');
+  console.log(`title: ${await page.title()}`);
+  console.log(`buttons (first 10):`, JSON.stringify(buttons.slice(0, 10), null, 2));
+  console.log(`inputs:`, JSON.stringify(inputs, null, 2));
+  console.log(`data-testids:`, JSON.stringify(dataAttrs, null, 2));
+  console.log(`sliders:`, JSON.stringify(sliders.slice(0, 8), null, 2));
+});


### PR DESCRIPTION
## Why

Audited 3 weeks of Lambda CloudWatch logs. **The only distinct error class** was this from \`express-rate-limit\`:

\`\`\`
ValidationError: The 'X-Forwarded-For' header is set but the Express
'trust proxy' setting is false (default). This could indicate a
misconfiguration which would prevent express-rate-limit from accurately
identifying users.
\`\`\`

It was firing on **every** rate-limited request since PR #146 deployed.

## What was broken

Without \`app.set('trust proxy', N)\`, Express ignores \`X-Forwarded-For\` and reports \`req.ip\` as the **connecting peer** (which is API Gateway, not the user). That had two consequences:

1. **Rate limiting was global, not per-IP.** Every request from every user got bucketed under the same Lambda-side IP, so the first 20 logins from anyone in the world consumed the bucket for everyone.
2. The CloudWatch error stream filled up with validation warnings.

## Fix

Set \`trust proxy: 2\` in \`config/express.js\` to match our 2-hop chain (CloudFront → API Gateway HTTP API → Lambda). Express now takes the correct \`X-Forwarded-For\` entry as \`req.ip\`, and rate-limit buckets requests per real client IP.

## Test plan
- [x] \`npm test\` — 223 passing
- [x] Verified API Gateway access logs show real client IPs (e.g. \`24.142.59.192\`, \`91.126.178.249\`) — these will now be the rate-limit keys
- [ ] Post-deploy: confirm the \`ValidationError\` log entries stop appearing
- [ ] Post-deploy: scan \`chronas-rate-limits\` table → entries should now show distinct IPs (not all the same APIGW IP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)