### PR TITLE
fix(getLinked): route Marker.find _id $in through BatchGetItem

### DIFF
--- a/server/models/dynamo/marker.dynamo.js
+++ b/server/models/dynamo/marker.dynamo.js
@@ -16,6 +16,9 @@ export default class MarkerDynamo extends DynamoDocument {
   static tableName = TABLE;
 
   static find(filter = {}) {
+    if (filter._id && filter._id.$in) {
+      return new BatchGetProxy(filter._id.$in);
+    }
     return new DynamoQuery(MarkerDynamo, filter);
   }
 
@@ -186,17 +189,44 @@ async function paginatedQuery(client, baseParams) {
 
 async function batchGetByWikis(wikiArray) {
   const ids = wikiArray.map(w => decodeURIComponent(w));
+  return batchGetByIds(ids);
+}
+
+async function batchGetByIds(ids) {
   const all = [];
   for (let i = 0; i < ids.length; i += 100) {
     const chunk = ids.slice(i, i + 100);
     const { Responses } = await batchGetWithRetry({
       RequestItems: {
-        [TABLE]: { Keys: chunk.map(_id => ({ _id })) }
+        [TABLE]: { Keys: chunk.map(_id => ({ _id: String(_id) })) }
       }
     });
     if (Responses?.[TABLE]) all.push(...Responses[TABLE]);
   }
   return all;
+}
+
+class BatchGetProxy {
+  constructor(ids) { this._ids = ids; this._lean = false; }
+  lean() { this._lean = true; return this; }
+  sort() { return this; }
+  skip() { return this; }
+  limit() { return this; }
+  async exec() {
+    const items = await batchGetByIds(this._ids);
+    if (this._lean) return items;
+    return items.map(i => new MarkerDynamo(i));
+  }
+  then(ok, fail) { return this.exec().then(ok, fail); }
+  catch(fn) { return this.exec().catch(fn); }
+  countDocuments() {
+    const promise = (async () => (await batchGetByIds(this._ids)).length)();
+    return {
+      exec: () => promise,
+      then: (ok, fail) => promise.then(ok, fail),
+      catch: (fn) => promise.catch(fn)
+    };
+  }
 }
 
 async function scanLimited(limit) {

--- a/server/models/dynamo/metadata.dynamo.js
+++ b/server/models/dynamo/metadata.dynamo.js
@@ -134,6 +134,14 @@ class BatchGetProxy {
   }
   then(ok, fail) { return this.exec().then(ok, fail); }
   catch(fn) { return this.exec().catch(fn); }
+  countDocuments() {
+    const promise = (async () => (await batchGetByIds(this._ids)).length)();
+    return {
+      exec: () => promise,
+      then: (ok, fail) => promise.then(ok, fail),
+      catch: (fn) => promise.catch(fn)
+    };
+  }
 }
 
 async function batchGetByIds(ids) {

--- a/server/tests/unit/dynamo-cost-optimization.test.js
+++ b/server/tests/unit/dynamo-cost-optimization.test.js
@@ -251,3 +251,27 @@ describe('Fix: $in arrays larger than 100 do not crash DynamoDB (issue #132)', (
     expect(foundIds).to.deep.equal([...real].sort());
   });
 });
+
+describe('Fix: $in expression byte-size limit (FilterExpression > 4096 bytes)', () => {
+  // Regression test for the production bug observed 2026-05-03..05-07: getLinked
+  // built FilterExpressions of 4767–9648 bytes when called with many long ids,
+  // crashing the Lambda with ValidationException ("Expression size has exceeded
+  // the maximum allowed size"). The fix routes _id $in queries through
+  // BatchGetItem, which uses Keys (not FilterExpression) and is immune to that
+  // limit. These tests exercise input shapes that would have busted the limit.
+  it('Marker.find with 200 long-id $in (~12kb of ids) does not crash', async () => {
+    const ids = Array.from({ length: 200 }, (_, i) =>
+      `e_some_very_long_event_identifier_with_lots_of_characters_${i}_${'x'.repeat(20)}`
+    );
+    const results = await MarkerDynamo.find({ _id: { $in: ids } }).lean().exec();
+    expect(results).to.be.an('array').that.is.empty;
+  });
+
+  it('Metadata.find with 200 long-id $in (~12kb of ids) does not crash', async () => {
+    const ids = Array.from({ length: 200 }, (_, i) =>
+      `a_ruler__Some_very_long_kingdom_name_that_makes_the_expression_huge_${i}`
+    );
+    const results = await MetadataDynamo.find({ _id: { $in: ids } }).lean().exec();
+    expect(results).to.be.an('array').that.is.empty;
+  });
+});


### PR DESCRIPTION
## Why

3 weeks of CloudWatch logs show one DynamoDB ValidationException pattern still firing in prod after my earlier fixes — including **2 occurrences today** (2026-05-08 11:06):

\`\`\`
ValidationException: Invalid FilterExpression: Expression size has exceeded
the maximum allowed size; expression size: 4767
\`\`\`

Real users from 4 countries hit this over the audit window — every \`getLinked\` call on a heavily-linked entity (e.g. \`e_World_War_II\` has 178+145 links).

## Root cause

\`server/controllers/metadata.controller.js:388\` calls:

\`\`\`js
Marker.find({ _id: { $in: markerIdList } }).lean().exec()
\`\`\`

\`MetadataDynamo.find\` already routes \`_id $in\` to **BatchGetProxy** ([metadata.dynamo.js:20](server/models/dynamo/metadata.dynamo.js#L20)), but \`MarkerDynamo.find\` did not — it always built a \`DynamoQuery → Scan\` with a \`FilterExpression\`. Even with the per-IN-clause chunking from PR #132, the resulting expression **string** can exceed DynamoDB's hard 4096-byte limit when the \`$in\` array has long IDs:

> ~50 metadata IDs averaging 90 chars each = ~4500 bytes after \`#_id IN (:v0,...)\` + ExpressionAttributeNames + ExpressionAttributeValues

## Fix

Mirror the Metadata pattern on Marker:

- \`MarkerDynamo.find({_id: {$in: ids}})\` now returns \`BatchGetProxy\` (uses BatchGetItem with Keys, immune to FilterExpression byte limits).
- New \`batchGetByIds\` helper on Marker; existing \`batchGetByWikis\` delegates to it.
- Both BatchGetProxy classes (Marker + Metadata) gain a \`countDocuments()\` method so the existing empty-\`$in\` regression test still passes.

## Tests

- 2 new unit tests in \`dynamo-cost-optimization.test.js\` covering the byte-overflow case (200 long-id \`$in\`, ~12 KB of IDs) for both Marker and Metadata
- All 225 existing tests pass

## Pattern audit summary

| Pattern | Last seen | Status |
|---|---|---|
| Pattern 1 — Expression size > 4096 bytes | **today** | **fixed by this PR** |
| Pattern 2 — IN operator > 100 operands | 2026-05-04 | fixed by PR #132 |
| Pattern 3 — ExpressionAttributeValues empty | 2026-05-03 | fixed by PR #129 |

## Test plan
- [x] \`npm test\` — 225 passing (was 223 + 2 new)
- [ ] Post-deploy: monitor CloudWatch for \`Expression size has exceeded\` errors → should drop to zero
- [ ] Post-deploy: \`curl https://api.chronas.org/v1/metadata/links/getLinked?source=1:e_World_War_II\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)