### PR TITLE
test(postman): regression test for getLinked on high-fanout entity

### DIFF
--- a/PostmanTests/chronas-enhanced.postman_collection.json
+++ b/PostmanTests/chronas-enhanced.postman_collection.json
@@ -379,6 +379,66 @@
           }
         },
         {
+          "name": "Get Linked Metadata - high-fanout entity (regression #149)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Regression for the DynamoDB FilterExpression byte-overflow bug fixed in PR #149.",
+                  "// e_World_War_II has 178 marker links + 145 metadata links — enough that the",
+                  "// pre-fix Scan+FilterExpression path crashed with 'Expression size has exceeded",
+                  "// the maximum allowed size'. With the BatchGetItem fix this must respond cleanly.",
+                  "pm.test('Status is not 5xx (BatchGet path is used, not Scan+FilterExpression)', function () {",
+                  "    pm.expect(pm.response.code).to.be.lessThan(500);",
+                  "});",
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "pm.test('Response contains map and media arrays', function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('map');",
+                  "    pm.expect(jsonData).to.have.property('media');",
+                  "    pm.expect(jsonData.map).to.be.an('array');",
+                  "    pm.expect(jsonData.media).to.be.an('array');",
+                  "});",
+                  "pm.test('High-fanout entity returns substantial link payload (>50 total)', function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    var total = jsonData.map.length + jsonData.media.length;",
+                  "    pm.expect(total).to.be.greaterThan(50);",
+                  "});",
+                  "pm.test('Response time under 3 seconds', function () {",
+                  "    pm.expect(pm.response.responseTime).to.be.below(3000);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/metadata/culture/getLinked?source=1:e_World_War_II",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "metadata",
+                "culture",
+                "getLinked"
+              ],
+              "query": [
+                {
+                  "key": "source",
+                  "value": "1:e_World_War_II"
+                }
+              ]
+            }
+          }
+        },
+        {
           "name": "Create Metadata",
           "event": [
             {


### PR DESCRIPTION
## Why

Adds a Postman regression test for the bug PR #149 fixed. The deploy pipeline runs the Postman suite post-deploy with auto-rollback on failure, so this guards against re-introducing the byte-overflow path.

## What

New test in the Metadata folder: \`Get Linked Metadata - high-fanout entity (regression #149)\`.

\`e_World_War_II\` has 178 marker links + 145 metadata links (323 total). Before #149 this consistently crashed with:

\`\`\`
ValidationException: Invalid FilterExpression: Expression size has exceeded
the maximum allowed size; expression size: 4767
\`\`\`

The test asserts:
- status < 500 (proves the Scan+FilterExpression path is no longer reachable)
- status === 200 (response well-formed)
- \`map\` + \`media\` arrays present
- \`map.length + media.length > 50\` (full fan-out fetched, not silently truncated)
- response time < 3s (BatchGet is ~5x faster than the old Scan: 1.87s → ~250ms)

## Verified locally against prod

\`\`\`
✓  Status is not 5xx (BatchGet path is used, not Scan+FilterExpression)
✓  Status is 200
✓  Response contains map and media arrays
✓  High-fanout entity returns substantial link payload (>50 total)
✓  Response time under 3 seconds
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)