### PR TITLE
fix(rate-limit): window-keyed counters, fail-open, infra-as-code, unit tests

### DIFF
--- a/infra/apply-lambda-config.sh
+++ b/infra/apply-lambda-config.sh
@@ -153,6 +153,53 @@ run_or_print aws --profile "$PROFILE" iam put-role-policy \
   --policy-name "$INLINE_POLICY_NAME" \
   --policy-document "file://$INLINE_POLICY_FILE"
 
+# --- DynamoDB: rate-limit counter table -------------------------------------
+# Used by server/middleware/dynamo-rate-store.js for per-IP rate limiting on
+# /auth/* and /contact. Without this table the auth path fails open (logs a
+# warning and lets the request through), but a properly configured prod
+# environment should have it. Idempotent: skips if the table already exists.
+RATE_TABLE="chronas-rate-limits"
+if aws "${AWS_COMMON[@]}" dynamodb describe-table --table-name "$RATE_TABLE" >/dev/null 2>&1; then
+  log "DynamoDB table $RATE_TABLE exists — verifying TTL + deletion protection"
+
+  TTL_STATUS="$(aws "${AWS_COMMON[@]}" dynamodb describe-time-to-live \
+    --table-name "$RATE_TABLE" \
+    --query 'TimeToLiveDescription.TimeToLiveStatus' --output text 2>/dev/null || echo NONE)"
+  if [[ "$TTL_STATUS" != "ENABLED" && "$TTL_STATUS" != "ENABLING" ]]; then
+    log "Enabling TTL on expires_at"
+    run_or_print aws "${AWS_COMMON[@]}" dynamodb update-time-to-live \
+      --table-name "$RATE_TABLE" \
+      --time-to-live-specification "Enabled=true, AttributeName=expires_at"
+  fi
+
+  DEL_PROT="$(aws "${AWS_COMMON[@]}" dynamodb describe-table \
+    --table-name "$RATE_TABLE" \
+    --query 'Table.DeletionProtectionEnabled' --output text)"
+  if [[ "$DEL_PROT" != "True" ]]; then
+    log "Enabling deletion protection on $RATE_TABLE"
+    run_or_print aws "${AWS_COMMON[@]}" dynamodb update-table \
+      --table-name "$RATE_TABLE" \
+      --deletion-protection-enabled
+  fi
+else
+  log "Creating DynamoDB table $RATE_TABLE (PAY_PER_REQUEST + TTL + deletion-protection)"
+  run_or_print aws "${AWS_COMMON[@]}" dynamodb create-table \
+    --table-name "$RATE_TABLE" \
+    --attribute-definitions AttributeName=_id,AttributeType=S \
+    --key-schema AttributeName=_id,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST \
+    --tags Key=app,Value=chronas Key=auto-stop,Value=no Key=auto-delete,Value=never
+  if [[ "$APPLY" == "yes" ]]; then
+    aws "${AWS_COMMON[@]}" dynamodb wait table-exists --table-name "$RATE_TABLE"
+    aws "${AWS_COMMON[@]}" dynamodb update-time-to-live \
+      --table-name "$RATE_TABLE" \
+      --time-to-live-specification "Enabled=true, AttributeName=expires_at"
+    aws "${AWS_COMMON[@]}" dynamodb update-table \
+      --table-name "$RATE_TABLE" \
+      --deletion-protection-enabled
+  fi
+fi
+
 # --- Summary -----------------------------------------------------------------
 log "Done. Snapshotting post-apply state"
 aws "${AWS_COMMON[@]}" lambda get-function-configuration --function-name "$FN" \

--- a/server/middleware/dynamo-rate-store.js
+++ b/server/middleware/dynamo-rate-store.js
@@ -1,60 +1,73 @@
-import { UpdateCommand, DeleteCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import debug from 'debug';
 
 import { getDocClient, tableName } from '../models/dynamo/dynamo-client.js';
 
 const TABLE = tableName('rate-limits');
+const debugLog = debug('chronas-api:rate-store');
 
+/**
+ * DynamoDB-backed store for express-rate-limit.
+ *
+ * Counter keys are scoped by both client key AND window start time, so each
+ * fixed window gets its own item:
+ *
+ *   prefix:clientKey:windowStart
+ *
+ * No counter reset is ever needed (old items expire via TTL), which removes
+ * the rollover race that a "Update -> if expired Delete -> Update" approach
+ * has at the window boundary.
+ *
+ * On DynamoDB errors the store fails OPEN: we log and report a hit count of
+ * 1, so a transient DDB problem can't lock real users out. This is the
+ * standard tradeoff express-rate-limit recommends for an external store.
+ */
 export class DynamoRateLimitStore {
   constructor({ prefix = '', windowMs }) {
+    if (!prefix) throw new Error('DynamoRateLimitStore: prefix is required');
+    if (!windowMs) throw new Error('DynamoRateLimitStore: windowMs is required');
     this.prefix = prefix;
     this.windowMs = windowMs;
-    this.localKeys = new Map();
   }
 
-  init(options) {
-    if (!this.windowMs) this.windowMs = options.windowMs;
+  init(_options) {
+    // express-rate-limit calls init(); windowMs is required at construction
+    // time (we use it to bucket items by window) so nothing to do here.
   }
 
-  _id(key) {
-    return `${this.prefix}:${key}`;
+  _windowStart(now = Date.now()) {
+    return Math.floor(now / this.windowMs) * this.windowMs;
   }
 
-  async increment(key) {
-    const id = this._id(key);
+  _id(clientKey, windowStart) {
+    return `${this.prefix}:${clientKey}:${windowStart}`;
+  }
+
+  async increment(clientKey) {
     const now = Date.now();
-    const expiresAt = Math.floor((now + this.windowMs) / 1000);
+    const windowStart = this._windowStart(now);
+    const resetTime = new Date(windowStart + this.windowMs);
+    const id = this._id(clientKey, windowStart);
+    const expiresAt = Math.floor((windowStart + this.windowMs) / 1000) + 60;
 
-    const { Attributes } = await getDocClient().send(new UpdateCommand({
-      TableName: TABLE,
-      Key: { _id: id },
-      UpdateExpression: 'ADD #c :one SET expires_at = if_not_exists(expires_at, :exp), reset_at = if_not_exists(reset_at, :reset)',
-      ExpressionAttributeNames: { '#c': 'count' },
-      ExpressionAttributeValues: { ':one': 1, ':exp': expiresAt, ':reset': now + this.windowMs },
-      ReturnValues: 'ALL_NEW'
-    }));
-
-    let totalHits = Attributes?.count ?? 1;
-    let resetAt = Attributes?.reset_at ?? (now + this.windowMs);
-
-    if (now >= resetAt) {
-      await getDocClient().send(new DeleteCommand({ TableName: TABLE, Key: { _id: id } }));
-      const fresh = await getDocClient().send(new UpdateCommand({
+    try {
+      const { Attributes } = await getDocClient().send(new UpdateCommand({
         TableName: TABLE,
         Key: { _id: id },
-        UpdateExpression: 'SET #c = :one, expires_at = :exp, reset_at = :reset',
+        UpdateExpression: 'ADD #c :one SET expires_at = if_not_exists(expires_at, :exp)',
         ExpressionAttributeNames: { '#c': 'count' },
-        ExpressionAttributeValues: { ':one': 1, ':exp': expiresAt, ':reset': now + this.windowMs },
+        ExpressionAttributeValues: { ':one': 1, ':exp': expiresAt },
         ReturnValues: 'ALL_NEW'
       }));
-      totalHits = fresh.Attributes?.count ?? 1;
-      resetAt = fresh.Attributes?.reset_at ?? (now + this.windowMs);
+      return { totalHits: Attributes?.count ?? 1, resetTime };
+    } catch (err) {
+      debugLog('increment failed (fail-open): %s %s', err.name, err.message);
+      return { totalHits: 1, resetTime };
     }
-
-    return { totalHits, resetTime: new Date(resetAt) };
   }
 
-  async decrement(key) {
-    const id = this._id(key);
+  async decrement(clientKey) {
+    const id = this._id(clientKey, this._windowStart());
     try {
       await getDocClient().send(new UpdateCommand({
         TableName: TABLE,
@@ -65,20 +78,35 @@ export class DynamoRateLimitStore {
         ExpressionAttributeValues: { ':neg': -1, ':zero': 0 }
       }));
     } catch (err) {
-      if (err.name !== 'ConditionalCheckFailedException') throw err;
+      if (err.name !== 'ConditionalCheckFailedException') {
+        debugLog('decrement failed (ignored): %s %s', err.name, err.message);
+      }
     }
   }
 
-  async resetKey(key) {
-    await getDocClient().send(new DeleteCommand({ TableName: TABLE, Key: { _id: this._id(key) } }));
+  async resetKey(clientKey) {
+    const { DeleteCommand } = await import('@aws-sdk/lib-dynamodb');
+    const id = this._id(clientKey, this._windowStart());
+    try {
+      await getDocClient().send(new DeleteCommand({ TableName: TABLE, Key: { _id: id } }));
+    } catch (err) {
+      debugLog('resetKey failed (ignored): %s %s', err.name, err.message);
+    }
   }
 
-  async get(key) {
-    const { Item } = await getDocClient().send(new GetCommand({
-      TableName: TABLE,
-      Key: { _id: this._id(key) }
-    }));
-    if (!Item) return undefined;
-    return { totalHits: Item.count ?? 0, resetTime: new Date(Item.reset_at ?? Date.now()) };
+  async get(clientKey) {
+    const windowStart = this._windowStart();
+    const id = this._id(clientKey, windowStart);
+    try {
+      const { Item } = await getDocClient().send(new GetCommand({ TableName: TABLE, Key: { _id: id } }));
+      if (!Item) return undefined;
+      return {
+        totalHits: Item.count ?? 0,
+        resetTime: new Date(windowStart + this.windowMs)
+      };
+    } catch (err) {
+      debugLog('get failed (fail-open): %s %s', err.name, err.message);
+      return undefined;
+    }
   }
 }

--- a/server/tests/helpers/dynamodb-local.js
+++ b/server/tests/helpers/dynamodb-local.js
@@ -252,6 +252,12 @@ async function loadTableDefs() {
       ]
     },
     {
+      TableName: `${prefix}-rate-limits`,
+      AttributeDefinitions: [{ AttributeName: '_id', AttributeType: 'S' }],
+      KeySchema: [{ AttributeName: '_id', KeyType: 'HASH' }],
+      BillingMode: 'PAY_PER_REQUEST'
+    },
+    {
       TableName: `${prefix}-board`,
       AttributeDefinitions: [
         { AttributeName: 'PK', AttributeType: 'S' },

--- a/server/tests/unit/dynamo-rate-store.test.js
+++ b/server/tests/unit/dynamo-rate-store.test.js
@@ -1,0 +1,169 @@
+import { expect } from 'chai';
+
+import { setupDynamoLocal, teardownDynamoLocal, clearTable } from '../helpers/dynamodb-local.js';
+
+const TABLE = 'chronas-rate-limits';
+
+let DynamoRateLimitStore;
+
+before(async function () {
+  this.timeout(15000);
+  await setupDynamoLocal();
+  ({ DynamoRateLimitStore } = await import('../../middleware/dynamo-rate-store.js'));
+});
+
+after(async () => {
+  await teardownDynamoLocal();
+});
+
+describe('DynamoRateLimitStore', () => {
+  beforeEach(async () => {
+    await clearTable(TABLE);
+  });
+
+  describe('increment()', () => {
+    it('increments a fresh counter to 1', async () => {
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+      const result = await store.increment('1.2.3.4');
+      expect(result.totalHits).to.equal(1);
+      expect(result.resetTime).to.be.instanceOf(Date);
+    });
+
+    it('increments an existing counter to 2', async () => {
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+      await store.increment('1.2.3.4');
+      const second = await store.increment('1.2.3.4');
+      expect(second.totalHits).to.equal(2);
+    });
+
+    it('isolates counters by prefix', async () => {
+      const auth = new DynamoRateLimitStore({ prefix: 'auth', windowMs: 60_000 });
+      const contact = new DynamoRateLimitStore({ prefix: 'contact', windowMs: 60_000 });
+      await auth.increment('1.2.3.4');
+      await auth.increment('1.2.3.4');
+      const contactResult = await contact.increment('1.2.3.4');
+      expect(contactResult.totalHits).to.equal(1);
+    });
+
+    it('isolates counters by client key (per-IP)', async () => {
+      const store = new DynamoRateLimitStore({ prefix: 'auth', windowMs: 60_000 });
+      await store.increment('1.2.3.4');
+      await store.increment('1.2.3.4');
+      const other = await store.increment('5.6.7.8');
+      expect(other.totalHits).to.equal(1);
+    });
+
+    it('resetTime aligns to the next window boundary', async () => {
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+      const now = Date.now();
+      const result = await store.increment('1.2.3.4');
+      const ms = result.resetTime.getTime();
+      // Window-aligned: ms should be a multiple of 60000 and within ~1 window of now
+      expect(ms % 60_000).to.equal(0);
+      expect(ms).to.be.greaterThan(now);
+      expect(ms).to.be.at.most(now + 60_000);
+    });
+
+    it('items in different windows do not collide (no rollover race)', async () => {
+      // Simulate two windows by using two stores with different windowMs perspectives.
+      // Easier: build the item id manually for an old window and confirm a fresh
+      // increment in the current window starts at 1.
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+
+      // increment in current window
+      await store.increment('1.2.3.4');
+      await store.increment('1.2.3.4');
+
+      // craft a counter for the next window manually
+      const nextWindow = Math.floor(Date.now() / 60_000) * 60_000 + 60_000;
+      const { getDocClient } = await import('../../models/dynamo/dynamo-client.js');
+      const { UpdateCommand } = await import('@aws-sdk/lib-dynamodb');
+      await getDocClient().send(new UpdateCommand({
+        TableName: TABLE,
+        Key: { _id: `test:1.2.3.4:${nextWindow}` },
+        UpdateExpression: 'ADD #c :one',
+        ExpressionAttributeNames: { '#c': 'count' },
+        ExpressionAttributeValues: { ':one': 1 }
+      }));
+
+      // current-window counter must still report 2 (next-window item didn't pollute)
+      const result = await store.increment('1.2.3.4');
+      expect(result.totalHits).to.equal(3);
+    });
+
+    it('fails OPEN when DynamoDB is unavailable', async () => {
+      // Point to a non-existent table by using a custom store class instance.
+      // We simulate by stubbing the doc client.
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+      const { getDocClient } = await import('../../models/dynamo/dynamo-client.js');
+      const realClient = getDocClient();
+      const originalSend = realClient.send.bind(realClient);
+      realClient.send = () => Promise.reject(new Error('simulated DDB outage'));
+
+      try {
+        const result = await store.increment('1.2.3.4');
+        expect(result.totalHits).to.equal(1);
+        expect(result.resetTime).to.be.instanceOf(Date);
+      } finally {
+        realClient.send = originalSend;
+      }
+    });
+  });
+
+  describe('resetKey()', () => {
+    it('removes the current-window counter for a single key', async () => {
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+      await store.increment('1.2.3.4');
+      await store.increment('1.2.3.4');
+      await store.resetKey('1.2.3.4');
+      const result = await store.increment('1.2.3.4');
+      expect(result.totalHits).to.equal(1);
+    });
+  });
+
+  describe('decrement()', () => {
+    it('decrements an existing counter', async () => {
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+      await store.increment('1.2.3.4');
+      await store.increment('1.2.3.4');
+      await store.decrement('1.2.3.4');
+      const result = await store.increment('1.2.3.4');
+      expect(result.totalHits).to.equal(2);
+    });
+
+    it('does not throw when decrementing past zero', async () => {
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+      // No prior increment — counter doesn't exist
+      await store.decrement('1.2.3.4');
+      const result = await store.increment('1.2.3.4');
+      expect(result.totalHits).to.equal(1);
+    });
+  });
+
+  describe('get()', () => {
+    it('returns undefined for an unknown key', async () => {
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+      const result = await store.get('never-seen');
+      expect(result).to.be.undefined;
+    });
+
+    it('returns current totalHits and resetTime', async () => {
+      const store = new DynamoRateLimitStore({ prefix: 'test', windowMs: 60_000 });
+      await store.increment('1.2.3.4');
+      await store.increment('1.2.3.4');
+      const result = await store.get('1.2.3.4');
+      expect(result.totalHits).to.equal(2);
+      expect(result.resetTime).to.be.instanceOf(Date);
+    });
+  });
+
+  describe('constructor validation', () => {
+    it('throws when prefix is missing', () => {
+      expect(() => new DynamoRateLimitStore({ windowMs: 1000 })).to.throw(/prefix/);
+    });
+
+    it('throws when windowMs is missing', () => {
+      expect(() => new DynamoRateLimitStore({ prefix: 'x' })).to.throw(/windowMs/);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Code review on PR #146 flagged five real issues. This addresses all of them.

## What

| Issue | Before | After |
|---|---|---|
| **Rollover race** | \`Update → if expired Delete + Update\` left a window where two concurrent requests at the boundary could clobber each other | Item key is \`prefix:clientKey:windowStart\` — each window gets its own item, no reset path, no race |
| **Fail-CLOSED on DDB error** | Throttle/outage threw 500 on every login | Fails OPEN: log + return \`totalHits=1\`. Standard express-rate-limit recommendation |
| **Dead \`localKeys = new Map()\`** | Field never read | Removed |
| **Table created out-of-band** | A fresh prod rebuild would 500 on every auth call until someone ran \`aws dynamodb create-table\` by hand | \`infra/apply-lambda-config.sh\` now creates+configures \`chronas-rate-limits\` (PAY_PER_REQUEST, TTL, deletion-protection, tags) idempotently |
| **Zero unit tests** | "223 existing tests still pass" | 14 new tests covering increment, prefix/client isolation, window alignment, **no-rollover-race across windows**, fail-open, resetKey, decrement (incl. clamp at zero), get, constructor validation |

## How the new key shape kills the rollover race

Old (race-prone): single item per (prefix, clientKey). Reset logic deletes and re-creates at window boundary — two writers can both delete then both insert count=1.

New (race-free): one item per (prefix, clientKey, windowStart). \`windowStart = floor(now / windowMs) * windowMs\`.

\`\`\`
t=0min: client X hits → item "auth:1.2.3.4:0"           count → 1
t=14min: client X hits → item "auth:1.2.3.4:0"          count → 2
t=15min: client X hits → item "auth:1.2.3.4:900000"     count → 1   (different item!)
\`\`\`

Old items expire via DynamoDB TTL on \`expires_at = windowStart + windowMs + 60s\` slack.

## Test plan
- [x] \`npm test\` — 239 passing (225 + 14 new)
- [x] Shell syntax check on \`apply-lambda-config.sh\`
- [x] Dry-run \`apply-lambda-config.sh\` — no errors, prints what it would do
- [ ] Post-deploy: hit \`/v1/auth/login\` ~25 times rapidly → 21st request returns 429
- [ ] Post-deploy: simulate DDB unavailability (e.g. by temporarily revoking IAM) → \`/v1/auth/login\` still works (fails open with debug log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)