### PR TITLE
refactor: extract shared BatchGetProxy module + reject silent .sort/.skip/.limit chains

### DIFF
--- a/server/models/dynamo/batch-get-proxy.js
+++ b/server/models/dynamo/batch-get-proxy.js
@@ -1,0 +1,48 @@
+/**
+ * Mongoose-style proxy for $in lookups on a primary-key-indexed table.
+ *
+ * Used by Model.find({_id: {$in: ids}}) call sites. Routes through
+ * BatchGetItem (Keys-based) which sidesteps the DynamoDB
+ * FilterExpression byte-size limit that bit getLinked in prod
+ * (see PR #149).
+ *
+ * Sort / skip / limit / paging are intentionally NOT supported on this
+ * shape — primary-key BatchGet has no notion of order, and historic
+ * call sites in this repo only chain .lean() / .exec() / .then(). If
+ * a future caller needs paging, run the query against a fixed-id list
+ * yourself or switch to a GSI scan.
+ */
+export class BatchGetProxy {
+  constructor({ ids, fetch, hydrate }) {
+    if (!Array.isArray(ids)) throw new Error('BatchGetProxy: ids must be an array');
+    if (typeof fetch !== 'function') throw new Error('BatchGetProxy: fetch must be a function');
+    if (typeof hydrate !== 'function') throw new Error('BatchGetProxy: hydrate must be a function');
+    this._ids = ids;
+    this._fetch = fetch;
+    this._hydrate = hydrate;
+    this._lean = false;
+  }
+
+  lean() { this._lean = true; return this; }
+
+  sort() { throw new Error('BatchGetProxy: .sort() is not supported on _id $in queries — call sort on the result array instead.'); }
+  skip() { throw new Error('BatchGetProxy: .skip() is not supported on _id $in queries — slice the result array instead.'); }
+  limit() { throw new Error('BatchGetProxy: .limit() is not supported on _id $in queries — slice the result array instead.'); }
+
+  async exec() {
+    const items = await this._fetch(this._ids);
+    return items.map(item => this._hydrate(item, this._lean));
+  }
+
+  then(ok, fail) { return this.exec().then(ok, fail); }
+  catch(fn) { return this.exec().catch(fn); }
+
+  countDocuments() {
+    const promise = (async () => (await this._fetch(this._ids)).length)();
+    return {
+      exec: () => promise,
+      then: (ok, fail) => promise.then(ok, fail),
+      catch: (fn) => promise.catch(fn)
+    };
+  }
+}

--- a/server/models/dynamo/marker.dynamo.js
+++ b/server/models/dynamo/marker.dynamo.js
@@ -6,6 +6,7 @@ import APIError from '../../helpers/APIError.js';
 import DynamoDocument from './dynamo-document.js';
 import DynamoQuery from './dynamo-query.js';
 import QueryProxy from './query-proxy.js';
+import { BatchGetProxy } from './batch-get-proxy.js';
 import { getDocClient, getDynamoClient, tableName, batchGetWithRetry } from './dynamo-client.js';
 
 const TABLE = tableName('markers');
@@ -17,7 +18,11 @@ export default class MarkerDynamo extends DynamoDocument {
 
   static find(filter = {}) {
     if (filter._id && filter._id.$in) {
-      return new BatchGetProxy(filter._id.$in);
+      return new BatchGetProxy({
+        ids: filter._id.$in,
+        fetch: batchGetByIds,
+        hydrate: (item, lean) => (lean ? item : new MarkerDynamo(item))
+      });
     }
     return new DynamoQuery(MarkerDynamo, filter);
   }
@@ -204,29 +209,6 @@ async function batchGetByIds(ids) {
     if (Responses?.[TABLE]) all.push(...Responses[TABLE]);
   }
   return all;
-}
-
-class BatchGetProxy {
-  constructor(ids) { this._ids = ids; this._lean = false; }
-  lean() { this._lean = true; return this; }
-  sort() { return this; }
-  skip() { return this; }
-  limit() { return this; }
-  async exec() {
-    const items = await batchGetByIds(this._ids);
-    if (this._lean) return items;
-    return items.map(i => new MarkerDynamo(i));
-  }
-  then(ok, fail) { return this.exec().then(ok, fail); }
-  catch(fn) { return this.exec().catch(fn); }
-  countDocuments() {
-    const promise = (async () => (await batchGetByIds(this._ids)).length)();
-    return {
-      exec: () => promise,
-      then: (ok, fail) => promise.then(ok, fail),
-      catch: (fn) => promise.catch(fn)
-    };
-  }
 }
 
 async function scanLimited(limit) {

--- a/server/models/dynamo/metadata.dynamo.js
+++ b/server/models/dynamo/metadata.dynamo.js
@@ -6,6 +6,7 @@ import APIError from '../../helpers/APIError.js';
 import DynamoDocument from './dynamo-document.js';
 import DynamoQuery from './dynamo-query.js';
 import QueryProxy from './query-proxy.js';
+import { BatchGetProxy } from './batch-get-proxy.js';
 import { getDocClient, getDynamoClient, tableName, batchGetWithRetry } from './dynamo-client.js';
 import { prepareForWrite, decodeFromRead } from './compression.js';
 import { cache } from '../../../config/config.js';
@@ -18,7 +19,11 @@ export default class MetadataDynamo extends DynamoDocument {
 
   static find(filter = {}) {
     if (filter._id && filter._id.$in) {
-      return new BatchGetProxy(filter._id.$in);
+      return new BatchGetProxy({
+        ids: filter._id.$in,
+        fetch: batchGetByIds,
+        hydrate: (item, lean) => (lean ? decodeFromRead(item) : new MetadataDynamo(decodeFromRead(item)))
+      });
     }
     return new DynamoQuery(MetadataDynamo, filter);
   }
@@ -118,29 +123,6 @@ export default class MetadataDynamo extends DynamoDocument {
       }
     }
     return this;
-  }
-}
-
-class BatchGetProxy {
-  constructor(ids) { this._ids = ids; this._lean = false; }
-  lean() { this._lean = true; return this; }
-  sort() { return this; }
-  skip() { return this; }
-  limit() { return this; }
-  async exec() {
-    const items = await batchGetByIds(this._ids);
-    if (this._lean) return items.map(i => decodeFromRead(i));
-    return items.map(i => new MetadataDynamo(decodeFromRead(i)));
-  }
-  then(ok, fail) { return this.exec().then(ok, fail); }
-  catch(fn) { return this.exec().catch(fn); }
-  countDocuments() {
-    const promise = (async () => (await batchGetByIds(this._ids)).length)();
-    return {
-      exec: () => promise,
-      then: (ok, fail) => promise.then(ok, fail),
-      catch: (fn) => promise.catch(fn)
-    };
   }
 }
 

--- a/server/tests/unit/batch-get-proxy.test.js
+++ b/server/tests/unit/batch-get-proxy.test.js
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+
+import { BatchGetProxy } from '../../models/dynamo/batch-get-proxy.js';
+
+describe('BatchGetProxy (shared)', () => {
+  const fakeFetch = async (ids) => ids.map(id => ({ _id: id, name: `name-${id}` }));
+  const passthrough = (item) => item;
+  const hydrate = (item, lean) => (lean ? item : { ...item, hydrated: true });
+
+  it('exec returns hydrated items', async () => {
+    const proxy = new BatchGetProxy({ ids: ['a', 'b'], fetch: fakeFetch, hydrate });
+    const items = await proxy.exec();
+    expect(items).to.have.length(2);
+    expect(items[0]).to.have.property('hydrated', true);
+  });
+
+  it('lean() returns raw items', async () => {
+    const proxy = new BatchGetProxy({ ids: ['a', 'b'], fetch: fakeFetch, hydrate });
+    const items = await proxy.lean().exec();
+    expect(items[0]).to.not.have.property('hydrated');
+    expect(items[0]._id).to.equal('a');
+  });
+
+  it('thenable: await proxy directly works', async () => {
+    const proxy = new BatchGetProxy({ ids: ['x'], fetch: fakeFetch, hydrate: passthrough });
+    const items = await proxy;
+    expect(items).to.have.length(1);
+  });
+
+  it('countDocuments().exec() returns the fetched length', async () => {
+    const proxy = new BatchGetProxy({ ids: ['a', 'b', 'c'], fetch: fakeFetch, hydrate: passthrough });
+    const count = await proxy.countDocuments().exec();
+    expect(count).to.equal(3);
+  });
+
+  it('empty ids resolves to empty array', async () => {
+    const proxy = new BatchGetProxy({ ids: [], fetch: async () => [], hydrate: passthrough });
+    const items = await proxy.exec();
+    expect(items).to.deep.equal([]);
+  });
+
+  describe('rejected chain methods', () => {
+    const proxy = () => new BatchGetProxy({ ids: ['a'], fetch: fakeFetch, hydrate: passthrough });
+
+    it('.sort() throws (would silently no-op before)', () => {
+      expect(() => proxy().sort({ name: 1 })).to.throw(/sort/);
+    });
+
+    it('.skip() throws', () => {
+      expect(() => proxy().skip(5)).to.throw(/skip/);
+    });
+
+    it('.limit() throws', () => {
+      expect(() => proxy().limit(10)).to.throw(/limit/);
+    });
+  });
+
+  describe('constructor validation', () => {
+    it('throws when ids is not an array', () => {
+      expect(() => new BatchGetProxy({ ids: 'a', fetch: fakeFetch, hydrate: passthrough })).to.throw(/array/);
+    });
+
+    it('throws when fetch is missing', () => {
+      expect(() => new BatchGetProxy({ ids: [], hydrate: passthrough })).to.throw(/fetch/);
+    });
+
+    it('throws when hydrate is missing', () => {
+      expect(() => new BatchGetProxy({ ids: [], fetch: fakeFetch })).to.throw(/hydrate/);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Two issues from the code review of PR #149:

1. **Duplicated BatchGetProxy class** — both \`marker.dynamo.js\` and \`metadata.dynamo.js\` carried near-identical copies, and both already grew \`countDocuments()\` separately. Drift was starting.
2. **Silent contract change**: \`.sort()/.skip()/.limit()\` chains were silently no-op'd. \`Marker.find({_id:{$in:ids}}).limit(10).exec()\` would silently return ALL items.

## What

Single parameterized \`BatchGetProxy\` in \`server/models/dynamo/batch-get-proxy.js\` that both models inject:
- \`fetch\` — a per-table \`batchGetByIds\` function
- \`hydrate\` — a per-table item constructor (handles compression decode for metadata, `String(_id)` cast already applied symmetrically by both fetch helpers)

\`.sort()/.skip()/.limit()\` now **throw**:

\`\`\`js
sort() { throw new Error('BatchGetProxy: .sort() is not supported on _id $in queries — call sort on the result array instead.'); }
\`\`\`

Verified before flipping: no caller in the repo chains those methods on an \`_id $in\` query.

## Tests

11 new tests in \`server/tests/unit/batch-get-proxy.test.js\`:
- exec / lean / thenable / countDocuments / empty ids
- 3 tests asserting \`.sort()\`, \`.skip()\`, \`.limit()\` throw
- 3 tests for constructor validation

**250 tests passing** (was 239 + 11 new).

## Test plan
- [x] \`npm test\` — 250 passing
- [x] grep confirmed no caller chains .sort/.skip/.limit on _id $in
- [ ] Post-deploy: hit \`/v1/metadata/links/getLinked?source=1:e_World_War_II\` → still 200, ~250ms (regression test in PR #150 catches this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)